### PR TITLE
extension-helpers 1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f95dd304a523d4ff6680d9504fa1d68a4dd03bf3bfbbe0ade4d927ed9e693f00
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - setuptools 43.0.0
     - setuptools_scm 6.2
+    - wheel
   run:
     - python
     - setuptools >=40.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,9 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: 'Utilities for building and installing packages with compiled extensions'
+  description: |
+    "The extension-helpers package includes convenience helpers to assist
+    with building Python packages with compiled C/Cython extensions."
   doc_url: https://extension-helpers.readthedocs.io/
   dev_url: https://github.com/astropy/extension-helpers
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools 43.0.0
-    - setuptools_scm 6.2
+    - setuptools
+    - setuptools_scm
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,12 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - setuptools_scm
   run:
-    - python >=3.6
+    - python
     - setuptools
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,12 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
+    - setuptools 43.0.0
+    - setuptools_scm 6.2
   run:
     - python
-    - setuptools
+    - setuptools >=40.2
+    - tomli >=1.0.0  # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,10 @@ requirements:
 test:
   imports:
     - extension_helpers
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/astropy/extension-helpers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True  # [py<38]
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "extension-helpers" %}
-{% set version = "0.1" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ac8a6fe91c6d98986a51a9f08ca0c7945f8fd70d95b662ced4040ae5eb973882
+  sha256: f95dd304a523d4ff6680d9504fa1d68a4dd03bf3bfbbe0ade4d927ed9e693f00
 
 build:
   noarch: python


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5032](https://anaconda.atlassian.net/browse/PKG-5032)
- [Upstream repository](https://github.com/astropy/extension-helpers/tree/v1.1.1)
- [Upstream changelog/diff](https://github.com/astropy/extension-helpers/blob/v1.1.1/CHANGES.md)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/astropy-feedstock/pull/17

### Explanation of changes:

- Set version and sha256
- Remove noarch
- Update dependencies per upstream requirements
- Linter fixes


[PKG-5032]: https://anaconda.atlassian.net/browse/PKG-5032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ